### PR TITLE
#85 코드 스플리팅__모든 페이지 레이지 임포트, 서스펜스

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -46,14 +46,21 @@ const routeArray = [
   },
 ]
 
-const suspendedRouterArray = routeArray.map((route) => ({
+const suspendedTestRouteArray = testRouteArray.map((route) => ({
+  path: route.path,
+  element: (
+    <Suspense fallback={<p>test route fallback</p>}>{route.element}</Suspense>
+  ),
+}))
+
+const suspendedRouteArray = routeArray.map((route) => ({
   path: route.path,
   element: <Suspense fallback={route.fallback}>{route.element}</Suspense>,
 }))
 
 const router = createBrowserRouter([
-  ...testRouteArray,
-  { element: <Layout />, children: suspendedRouterArray },
+  ...suspendedTestRouteArray,
+  { element: <Layout />, children: suspendedRouteArray },
   { path: '*', element: <NotFoundPage /> },
 ])
 

--- a/src/testRoutes/_gwonTestRouteArray.tsx
+++ b/src/testRoutes/_gwonTestRouteArray.tsx
@@ -1,5 +1,8 @@
-import GwonTagModalTest from './testPages/gwon/GwonTagModalTest'
-import GwonTestPage from './testPages/gwon/GwonTestPage'
+import { lazy } from 'react'
+
+// 테스트 라우트에서도 코드 스플리팅을 하려고 합니다!
+const GwonTagModalTest = lazy(() => import('./testPages/gwon/GwonTagModalTest'))
+const GwonTestPage = lazy(() => import('./testPages/gwon/GwonTestPage'))
 
 const gwonTestRouteArray = [
   { path: '/test/gwon', element: <GwonTestPage /> },

--- a/src/testRoutes/_hyejeongTestRouteArray.tsx
+++ b/src/testRoutes/_hyejeongTestRouteArray.tsx
@@ -1,6 +1,15 @@
-import HyejeongPageTitle from './testPages/hyejeong/HyejeongPageTitle'
-import HyejeongRecruitPage from './testPages/hyejeong/HyejeongRecruitPage'
-import HyejeongRecommendSection from './testPages/hyejeong/HyejeongRecommendSection'
+import { lazy } from 'react'
+
+// 테스트 라우트에서도 코드 스플리팅을 하려고 합니다!
+const HyejeongPageTitle = lazy(
+  () => import('./testPages/hyejeong/HyejeongPageTitle')
+)
+const HyejeongRecruitPage = lazy(
+  () => import('./testPages/hyejeong/HyejeongRecruitPage')
+)
+const HyejeongRecommendSection = lazy(
+  () => import('./testPages/hyejeong/HyejeongRecommendSection')
+)
 
 const hyejeongTestRouteArray = [
   {

--- a/src/testRoutes/_nariRouteArray.tsx
+++ b/src/testRoutes/_nariRouteArray.tsx
@@ -1,4 +1,7 @@
-import NariTastPage from './testPages/nari/_nariTastPage'
+import { lazy } from 'react'
+
+// 테스트 라우트에서도 코드 스플리팅을 하려고 합니다!
+const NariTastPage = lazy(() => import('./testPages/nari/_nariTastPage'))
 
 const nariRouteArray = [{ path: '/test/nari', element: <NariTastPage /> }]
 

--- a/src/testRoutes/_thepotTestRouteArray.tsx
+++ b/src/testRoutes/_thepotTestRouteArray.tsx
@@ -1,8 +1,21 @@
-import ThePottButtonPage from './testPages/thepott/ThePottButtonPage'
-import ThePottInputFamilyPage from './testPages/thepott/ThePottInputFamilyPage'
-import ThePottModalPage from './testPages/thepott/ThePottModalPage'
-import ThePottRoundBoxPage from './testPages/thepott/ThePottRoundBoxPage'
-import ThepottTestPage from './testPages/thepott/ThepottTestPage'
+import { lazy } from 'react'
+
+// 테스트 라우트에서도 코드 스플리팅을 하려고 합니다!
+const ThePottButtonPage = lazy(
+  () => import('./testPages/thepott/ThePottButtonPage')
+)
+const ThePottInputFamilyPage = lazy(
+  () => import('./testPages/thepott/ThePottInputFamilyPage')
+)
+const ThePottModalPage = lazy(
+  () => import('./testPages/thepott/ThePottModalPage')
+)
+const ThePottRoundBoxPage = lazy(
+  () => import('./testPages/thepott/ThePottRoundBoxPage')
+)
+const ThepottTestPage = lazy(
+  () => import('./testPages/thepott/ThepottTestPage')
+)
 
 const thepottTestRouteArray = [
   { path: '/test/thepott', element: <ThepottTestPage /> },


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #85

## 📸 스크린샷
<img width="850" height="535" alt="image" src="https://github.com/user-attachments/assets/d4487c5d-3b3d-4808-ace3-e03ae0920423" />



## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 테스트 라우트의 페이지를 모두 lazy import 하였습니다
2.이후 suspense로 감싸 라우터에 등록하였습니다
3. `localhost:5173/test/nari` 등의 모든 페이지도 이제 로딩 화면이 보입니다.
