### PR TITLE
#86 셀렉트 메뉴에서 콘텐트가 가려지는 버그

### DIFF
--- a/src/components/commonInGeneral/select/_SelectContent.tsx
+++ b/src/components/commonInGeneral/select/_SelectContent.tsx
@@ -1,10 +1,35 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 import { Vstack } from '../layout'
 import RoundBox from '../roundBox/RoundBox'
 import useSelectContext from './_useSelectContext'
 
 const SelectContent = ({ children }: { children: ReactNode }) => {
-  const { isOpened, triggerRef } = useSelectContext()
+  const { isOpened, setIsOpened, triggerRef } = useSelectContext()
+
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const handleClick = (event: MouseEvent) => {
+    if (!contentRef.current) {
+      return
+    }
+    if (
+      contentRef.current.contains(event.target as Node) ||
+      triggerRef.current?.contains(event.target as Node)
+    ) {
+      return
+    }
+
+    setIsOpened(false)
+  }
+
+  useEffect(() => {
+    if (!isOpened) {
+      return
+    }
+
+    window.addEventListener('mousedown', handleClick)
+    return () => window.removeEventListener('mousedown', handleClick)
+  }, [isOpened])
 
   if (!isOpened) {
     return null
@@ -16,6 +41,7 @@ const SelectContent = ({ children }: { children: ReactNode }) => {
 
   return (
     <RoundBox
+      ref={contentRef}
       style={{ top: triggerRef.current.offsetHeight + 4 }}
       padding="xs"
       className="absolute z-10 w-full"

--- a/src/components/commonInGeneral/select/_SelectTrigger.tsx
+++ b/src/components/commonInGeneral/select/_SelectTrigger.tsx
@@ -6,6 +6,7 @@ import useSelectContext from './_useSelectContext'
 const SelectTrigger = ({ children }: { children: string }) => {
   const { setIsOpened, selectedOption, selectedIcon, triggerRef } =
     useSelectContext()
+
   const handleClick = () => {
     setIsOpened((prev) => !prev)
   }

--- a/src/components/commonInGeneral/select/_useCloseSelectContent.ts
+++ b/src/components/commonInGeneral/select/_useCloseSelectContent.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react'
+import useSelectContext from './_useSelectContext'
+
+const useCloseSelectContent = () => {
+  const { isOpened, setIsOpened } = useSelectContext()
+
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const handleClick = (event: MouseEvent) => {
+    if (!contentRef.current) {
+      return
+    }
+    if (contentRef.current.contains(event.target as Node)) {
+      return
+    }
+
+    setIsOpened(false)
+  }
+
+  useEffect(() => {
+    if (!isOpened) {
+      return
+    }
+
+    window.addEventListener('click', handleClick)
+    return () => window.removeEventListener('click', handleClick)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpened])
+
+  return contentRef
+}
+
+export default useCloseSelectContent


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #86

## 📸 스크린샷

<img width="925" height="497" alt="image" src="https://github.com/user-attachments/assets/09996944-ac9d-42a2-9dc9-ab4e6c8c3234" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. Select Content의 z index를 10으로 설정해 밑의 컴포넌트가 이를 가리는 일이 없도록 하였습니다
2. window에 클릭 이벤트 리스너를 붙여서 셀렉트 콘텐트 외부 영역이 클릭되면 콘텐트를 접도록 하는 기능을 추가하였습니다.

현재 브랜치에서는 라운드 박스에서 `isBordered={false}`를 하면 점선 테두리가 생기는 버그가 있습니다. 다만, 이는 100번 PR에서 해결되어서 pull 하면 사라질 버그입니다.
