### PR TITLE
#110 공통 컴포넌트__프로필 이미지 컴포넌트 제작

### DIFF
--- a/src/components/commonInProject/ProfileImage/ProfileImage.tsx
+++ b/src/components/commonInProject/ProfileImage/ProfileImage.tsx
@@ -1,0 +1,36 @@
+import Img from '@/components/commonInProject/img/Img'
+import UserRound from '@/assets/user-round.svg'
+
+export type UrlType = string | null
+export type ImageSizeType = 'sm' | 'lg' | 'xl'
+export interface ProfileImageProps {
+  url: UrlType
+  size?: ImageSizeType
+}
+
+const makeImageSizeResult = (size: ImageSizeType) => {
+  switch (size) {
+    case 'sm':
+      return 'h-8 w-8'
+    case 'lg':
+      return 'h-12 w-12'
+    case 'xl':
+      return 'h-16 w-16'
+  }
+}
+
+const ProfileImage = ({ url, size = 'sm' }: ProfileImageProps) => {
+  const paddingClass = url ? '' : 'p-oz-sm'
+
+  return (
+    <div className={makeImageSizeResult(size)}>
+      <Img
+        src={url || UserRound}
+        fallbackImageUrl={UserRound}
+        className={`bg-primary-100 h-full w-full rounded-full ${paddingClass}`}
+      />
+    </div>
+  )
+}
+
+export default ProfileImage

--- a/src/components/recruit/applicantCard/ApplicantCard.tsx
+++ b/src/components/recruit/applicantCard/ApplicantCard.tsx
@@ -1,25 +1,12 @@
 import { Hstack, Vstack } from '@/components/commonInGeneral/layout'
-import Img from '@/components/commonInProject/img/Img'
 import {
   experienceStyles,
   statusStyles,
   type Applicant,
 } from '@/types/_applicantInterface'
 import { Calendar } from 'lucide-react'
-import UserRound from '@/assets/user-round.svg'
 import RoundBox from '@/components/commonInGeneral/roundBox/RoundBox'
-
-const ProfileImage = ({ url }: { url: string | null }) => {
-  return (
-    <div className="h-12 w-12">
-      <Img
-        src={url || UserRound}
-        fallbackImageUrl={UserRound}
-        className={`bg-primary-100 h-full rounded-full ${url || 'p-oz-sm'}`}
-      />
-    </div>
-  )
-}
+import ProfileImage from '@/components/commonInProject/ProfileImage/ProfileImage'
 
 const ApplicantCard = ({ applicant }: { applicant: Applicant }) => {
   const statusStyle = statusStyles[applicant.status]
@@ -34,7 +21,7 @@ const ApplicantCard = ({ applicant }: { applicant: Applicant }) => {
     >
       <Hstack gap="lg" className="h-[64px] w-[384px]">
         <Hstack className="items-center">
-          <ProfileImage url={applicant.application.profile_image} />
+          <ProfileImage url={applicant.application.profile_image} size="lg" />
         </Hstack>
         <Hstack gap="none" className="h-11 w-80 justify-between">
           <Vstack gap="none">


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #110

## 📸 스크린샷

<img width="473" height="933" alt="스크린샷 2025-10-24 오후 12 39 57" src="https://github.com/user-attachments/assets/22fcbd8b-121d-4ebf-bf6d-24fb2fd98a2a" />

<img width="712" height="933" alt="스크린샷 2025-10-23 오후 8 50 51" src="https://github.com/user-attachments/assets/8432ebae-21be-4dc6-ab73-78ec4209490b" />

<img width="473" height="933" alt="스크린샷 2025-10-24 오후 12 40 08" src="https://github.com/user-attachments/assets/4026f561-2f1d-41f4-877c-b76b95832aee" />

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. ApplicantCard 안에 있던 ProfileImage 컴포넌트를 공통 컴포넌트로 분리했습니다
2. size를 prop로 전달하여 이미지 크기를 조절할 수 있습니다 (defalt는 sm입니다)
 - sm: h-8 w-8
 - lg: h-12 w-12 
 - xl: h-16 w-16