### PR TITLE
#120 공통 컴포넌트__Tag__배경색 오류

### DIFF
--- a/src/components/commonInProject/tag/Tag.tsx
+++ b/src/components/commonInProject/tag/Tag.tsx
@@ -3,15 +3,15 @@ import type { Color, DivProps } from '@/types'
 const makeBgResult = (color: Color, isVivid: boolean) => {
   switch (color) {
     case 'mono':
-      return 'bg-gray-50'
+      return 'bg-gray-100'
     case 'primary':
-      return isVivid ? 'bg-primary-500' : 'bg-primary-50'
+      return isVivid ? 'bg-primary-500' : 'bg-primary-100'
     case 'danger':
-      return isVivid ? 'bg-danger-500' : 'bg-danger-50'
+      return isVivid ? 'bg-danger-500' : 'bg-danger-tag'
     case 'success':
-      return isVivid ? 'bg-success-500' : 'bg-success-50'
+      return isVivid ? 'bg-success-500' : 'bg-success-100'
     case 'blue':
-      return isVivid ? 'bg-blue-500' : 'bg-blue-50'
+      return isVivid ? 'bg-blue-500' : 'bg-blue-100'
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -54,6 +54,7 @@
 
   /* Danger (위험/에러) */
   --color-danger-50: #fef2f2;
+  --color-danger-tag: #fee2e2;
   --color-danger-border: #fecaca;
   --color-danger-100: #fca5a5;
   --color-danger-500: #ef4444;


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #120

## 📸 스크린샷

<img width="1029" height="864" alt="image" src="https://github.com/user-attachments/assets/d6fbeb23-db48-4b37-8dbc-a4d55bed6e63" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 빨간 태그의 배경색은 기존 전역 css 변수에 없어 `index.css`에 `--color-danger-tag` 색을 새로 등록했습니다.
2.`mono` tag가 회색 배경에서도 잘 보이게 더 진하게 색을 수정했습니다.
3. http://localhost:5173/test/hyejeong/apllicantcard 에서 결과물을 확인하실 수 있습니다.
