### PR TITLE
#153 마크다운 에디터__회색선 제거

### DIFF
--- a/src/components/commonInGeneral/markdownEditor/markdown.css
+++ b/src/components/commonInGeneral/markdownEditor/markdown.css
@@ -3,6 +3,7 @@
   height: unset !important;
   padding: var(--spacing-oz-sm) !important;
   font-size: 14px !important;
+  border-bottom: 1px solid var(--color-gray-200) !important;
 }
 
 .w-md-editor-toolbar li > button {
@@ -48,6 +49,9 @@
 
 .w-md-editor {
   border-radius: 0 !important;
+  padding: 0 !important;
+  box-shadow: none !important;
+  border-bottom: 1px solid var(--color-gray-200) !important;
 }
 .w-md-editor-text {
   height: 100% !important;


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #153

## 📸 스크린샷

<img width="843" height="53" alt="image" src="https://github.com/user-attachments/assets/d66b1629-a311-4b03-8cb8-18d6ddd54ffc" />
<img width="850" height="35" alt="image" src="https://github.com/user-attachments/assets/ed96283c-e03c-435b-aa92-b9453efad7fd" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 마크다운 에디터의 기본 css로 적용되어 있던 진한 회색선 테두리를, roundbox 기본 회색 테두리로 바꿨습니다
2. http://localhost:5173/recruit/write 에서 확인하실 수 있습니다
