### PR TITLE
#167 구인 공고 목록 페이지__태그 필터링 기능 구현

### DIFF
--- a/src/components/recruit/title/RecruitContent.tsx
+++ b/src/components/recruit/title/RecruitContent.tsx
@@ -14,12 +14,21 @@ import { useEffect, useState } from 'react'
 import useDebounce from '@/hooks/useDebounce'
 import NoSearchResult from '@/components/commonInProject/noSearchResult/NoSearchResult'
 
-const dummyGetRecruitWithParametersApi = (debounceValue: string) => {
+const dummyGetRecruitWithParametersApi = (
+  debounceValue: string,
+  tag: string | null
+) => {
   const setRecruitArray = useStudyHubStore.getState().setRecruitArray
 
-  const filteredRecruitArray = dummyRecruitArray.filter((recruit) =>
-    recruit.title.includes(debounceValue)
-  )
+  const filteredRecruitArray = dummyRecruitArray
+    .filter((recruit) => recruit.title.includes(debounceValue))
+    .filter((recruit) => {
+      if (!tag || tag === '전체 태그') {
+        return true
+      }
+      const nameArray = recruit.tags.map((tempTag) => tempTag.name)
+      return nameArray.includes(tag)
+    })
 
   setRecruitArray(filteredRecruitArray)
 }
@@ -33,16 +42,17 @@ const RecruitContent = () => {
 
   const [searchText, setSearchText] = useState('')
   const [debounceValue, cancel] = useDebounce(searchText, 500)
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
 
   useEffect(() => {
-    dummyGetRecruitWithParametersApi(debounceValue)
+    dummyGetRecruitWithParametersApi(debounceValue, selectedTag)
 
     if (debounceValue === '') {
       setIsSearching(false)
     } else {
       setIsSearching(true)
     }
-  }, [debounceValue])
+  }, [debounceValue, selectedTag])
 
   return (
     <Container className="py-oz-xxl flex flex-col items-center bg-gray-50">
@@ -67,7 +77,7 @@ const RecruitContent = () => {
           />
 
           <Hstack gap="none" className="gap-9">
-            <RecruitTagSelect />
+            <RecruitTagSelect setSelectedTag={setSelectedTag} />
             <RecruitOrderingSelect />
           </Hstack>
         </RoundBox>

--- a/src/components/recruit/title/_RecruitTagSelect.tsx
+++ b/src/components/recruit/title/_RecruitTagSelect.tsx
@@ -1,12 +1,51 @@
 import { Vstack } from '@/components/commonInGeneral/layout'
 import Select from '@/components/commonInGeneral/select/Select'
+import { dummyRecruitArray } from '@/testRoutes/testPages/hyejeong/dummy/dummyRecruitList'
 
-const RecruitTagSelect = () => {
+const calcTagArray = () => {
+  const tagRecords = dummyRecruitArray.reduce((outerAcc, recruit) => {
+    const dict = recruit.tags.reduce(
+      (innerAcc: Record<number, string>, tag) => {
+        innerAcc[tag.id] = tag.name
+        return innerAcc
+      },
+      {}
+    )
+
+    const newOuterAcc = { ...outerAcc, ...dict }
+    return newOuterAcc
+  }, {})
+
+  const tagArray = Object.values(tagRecords).sort() as string[]
+  return tagArray
+}
+
+interface RecruitTagSelectProps {
+  setSelectedTag: React.Dispatch<React.SetStateAction<string | null>>
+}
+
+const RecruitTagSelect = ({ setSelectedTag }: RecruitTagSelectProps) => {
+  const tagArray = calcTagArray()
+
+  const handleOptionSelect = (option: string | number) => {
+    if (typeof option !== 'string') {
+      throw new Error('---- 태그는 스트링이어야 합니다!')
+    }
+    setSelectedTag(option)
+  }
+
   return (
     <Vstack gap="none" className="w-full">
       <p className="mb-oz-sm">태그</p>
-      <Select onOptionSelect={() => null}>
+
+      <Select onOptionSelect={handleOptionSelect}>
         <Select.Trigger>전체 태그</Select.Trigger>
+        <Select.Content>
+          <Select.Option>전체 태그</Select.Option>
+          {tagArray.map((tag) => (
+            <Select.Option key={tag}>{tag}</Select.Option>
+          ))}
+        </Select.Content>
       </Select>
     </Vstack>
   )

--- a/src/testRoutes/testPages/hyejeong/dummy/dummyRecruitList.ts
+++ b/src/testRoutes/testPages/hyejeong/dummy/dummyRecruitList.ts
@@ -50,10 +50,10 @@ export const dummyRecruitArray: Recruit[] = [
     due_date: '2025-12-30T23:59:59Z',
     is_closed: false,
     tags: [
-      { id: 1, name: '블록체인' },
-      { id: 2, name: 'Web3' },
-      { id: 3, name: 'Solidity' },
-      { id: 4, name: '암호화폐' },
+      { id: 5, name: '블록체인' },
+      { id: 6, name: 'Web3' },
+      { id: 7, name: 'Solidity' },
+      { id: 8, name: '암호화폐' },
     ],
     lectures: [{ id: 201, title: '프론트엔드 기초', instructor: '김강사' }],
     study_group: {
@@ -84,10 +84,10 @@ export const dummyRecruitArray: Recruit[] = [
     due_date: '2025-12-30T23:59:59Z',
     is_closed: false,
     tags: [
-      { id: 1, name: 'Spring Boot' },
-      { id: 2, name: 'Java' },
-      { id: 3, name: '백엔드' },
-      { id: 4, name: '기업프로젝트' },
+      { id: 9, name: 'Spring Boot' },
+      { id: 10, name: 'Java' },
+      { id: 11, name: '백엔드' },
+      { id: 12, name: '기업프로젝트' },
     ],
     lectures: [{ id: 201, title: '프론트엔드 기초', instructor: '김강사' }],
     study_group: {
@@ -118,10 +118,10 @@ export const dummyRecruitArray: Recruit[] = [
     due_date: '2025-10-03T23:59:59Z',
     is_closed: false,
     tags: [
-      { id: 1, name: 'DevOps' },
-      { id: 2, name: 'AWS' },
-      { id: 3, name: '클라우드' },
-      { id: 4, name: '인프라' },
+      { id: 13, name: 'DevOps' },
+      { id: 14, name: 'AWS' },
+      { id: 15, name: '클라우드' },
+      { id: 16, name: '인프라' },
     ],
     lectures: [{ id: 201, title: '프론트엔드 기초', instructor: '김강사' }],
     study_group: {


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #167 

## 📸 스크린샷

<img width="462" height="676" alt="스크린샷 2025-10-29 오후 6 24 43" src="https://github.com/user-attachments/assets/5816568f-fd56-41d4-9e43-b6b9691bdda1" />

<img width="462" height="461" alt="스크린샷 2025-10-29 오후 6 24 52" src="https://github.com/user-attachments/assets/c3e865f6-5b5d-45a9-92fc-15f2560243c2" />

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 구인 목록 페이지에 태그 필터링 기능을 추가했습니다. 
2. 흥주님이 구현하신 로직을 참고하여 구조를 동일하게 맞췄습니다.
