### PR TITLE
#191 공고 세부 페이지__다운로드 기능 구현

### DIFF
--- a/src/components/recruit/detail/_RDAttachmentCard.tsx
+++ b/src/components/recruit/detail/_RDAttachmentCard.tsx
@@ -2,6 +2,7 @@ import Button from '@/components/commonInGeneral/button/Button'
 import { Hstack } from '@/components/commonInGeneral/layout'
 import RoundBox from '@/components/commonInGeneral/roundBox/RoundBox'
 import type { RecruitDetailAttachment } from '@/types'
+import downloadFile from '@/utils/downloadFile'
 import { ArrowDownToLine, FileText } from 'lucide-react'
 
 const FileIcon = () => {
@@ -22,7 +23,9 @@ const RDAttachmentCard = ({
       <Hstack className="gap-oz-lg items-center">
         <FileIcon />
         <p className="grow font-medium">{attachment.file_name}</p>
-        <Button>
+        <Button
+          onClick={() => downloadFile(attachment.url, attachment.file_name)}
+        >
           <ArrowDownToLine size={16} />
           다운로드
         </Button>

--- a/src/components/recruit/detail/_dummyRecruitDetailResponse.ts
+++ b/src/components/recruit/detail/_dummyRecruitDetailResponse.ts
@@ -81,6 +81,11 @@ This includes:
       file_name: 'ai_project_guide.pdf',
       url: 'https://example.com/files/ai_project_guide.pdf',
     },
+    {
+      id: 52,
+      file_name: 'arch_logo.jpg',
+      url: 'https://media.istockphoto.com/id/2206580869/ko/%EC%82%AC%EC%A7%84/%ED%97%98%EC%A4%80%ED%95%9C-%ED%95%B4%EC%95%88%EC%84%A0%EA%B3%BC-%EB%B0%94%EB%8B%A4-%EC%BD%94%EB%A5%B4%EC%8B%9C%EC%B9%B4%EC%9D%98-%EB%86%92%EC%9D%80-%EC%A0%84%EB%A7%9D.jpg?s=2048x2048&w=is&k=20&c=UQNSU7WinhgHAIlLv2HsqwxCoc2E_aaPN1FJc1xfjYQ=',
+    },
   ],
   expected_personnel: 5,
   expected_fee: 100000,

--- a/src/utils/downloadFile.ts
+++ b/src/utils/downloadFile.ts
@@ -1,60 +1,18 @@
 import api from '@/api/api'
 
-const downloadFile = async (url: string) => {
-  const respone = await api.get(url, { responseType: 'blob' })
+const downloadFile = async (url: string, file_name: string) => {
+  const response = await api.get(url, { responseType: 'blob' })
+  const blob = response.data
+  const fileURL = URL.createObjectURL(blob) // Create a temporary URL for the Blob
 
-  //   .then(response => {
-  //       // response.data is now a Blob object
-  //       const blob = response.data;
-  //       const fileURL = URL.createObjectURL(blob); // Create a temporary URL for the Blob
-  //       // You can then use fileURL to display images, initiate downloads, etc.
-  //       const link = document.createElement('a');
-  //       link.href = fileURL;
-  //       link.setAttribute('download', 'filename.ext'); // Suggested filename for download
-  //       document.body.appendChild(link);
-  //       link.click();
-  //       document.body.removeChild(link);
-  //       URL.revokeObjectURL(fileURL); // Clean up the temporary URL
-  //   })
-  //   .catch(error => {
-  //       console.error('Download failed:', error);
-  //   });
-  // const init = {
-  //   method: 'GET',
-  // }
-  //
-  // fetch(url, init)
-  //   .then((response) => {
-  //     if (!response.ok) {
-  //       throw new Error(`HTTP error! status: ${response.status}`)
-  //     }
-  //     return response.blob()
-  //   })
-  //   .then((blob) => {
-  //     // Create download - browser will handle the filename from Content-Disposition header
-  //     const downloadUrl = window.URL.createObjectURL(blob)
-  //     const link = document.createElement('a')
-  //     link.href = downloadUrl
-  //     link.download = '' // Empty download attribute lets browser use server's filename
-  //
-  //     // Trigger download
-  //     document.body.appendChild(link)
-  //     link.click()
-  //
-  //     // Cleanup
-  //     document.body.removeChild(link)
-  //     window.URL.revokeObjectURL(downloadUrl)
-  //
-  //     if (callback) {
-  //       callback({ success: true })
-  //     }
-  //   })
-  //   .catch((error) => {
-  //     console.error('Download error:', error)
-  //     if (callback) {
-  //       callback({ success: false, error: error.message })
-  //     }
-  //   })
+  const link = document.createElement('a')
+  link.href = fileURL
+  link.setAttribute('download', file_name) // Suggested filename for download
+  document.body.appendChild(link)
+  link.click()
+
+  document.body.removeChild(link)
+  URL.revokeObjectURL(fileURL) // Clean up the temporary URL
 }
 
 export default downloadFile


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #191

## 📸 스크린샷

<img width="999" height="496" alt="image" src="https://github.com/user-attachments/assets/795d3527-2b98-411b-b543-e93c11423e4b" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 공고 세부 페이지에서 첨부파일을 다운로드할 수 있게 만들었습니다
2. 임의로 넣은 파일 주소들은 CORS 정책에 의해 에러가 뜹니다. 구체적인 테스트는 api 연결 후 s3에 저장된 파일로 해볼 수 있을 것 같습니다

http://localhost:5173/recruit/401 에서 확인하실 수 있습니다
