### PR TITLE
#182 지원자 조회 모달__지원자 상세 조회 모달 연결

### DIFF
--- a/src/components/recruit/manageModal/ManageModal.tsx
+++ b/src/components/recruit/manageModal/ManageModal.tsx
@@ -21,9 +21,9 @@ const ManageModal = ({
   recruitContent,
   applicantArray,
 }: ManageModal) => {
-  const [selectedApplicantId, setSelectedApplicantId] = useState<number | null>(
-    null
-  ) // 선택된 지원자 id
+  const [_selectedApplicantId, setSelectedApplicantId] = useState<
+    number | null
+  >(null) // 선택된 지원자 id, api 연결할때 사용
 
   const modalKey = useStudyHubStore((state) => state.modalKey)
   const setModalKey = useStudyHubStore((state) => state.setModalKey)
@@ -38,7 +38,6 @@ const ManageModal = ({
     setSelectedApplicantId(applicantId)
     setModalKey('manageDetail')
     // 지원자 상세 정보 api 호출..?
-    console.log(selectedApplicantId) // 임시
     setApplicantDetail(dummyApplicantDetail)
   }
 


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #182 

## 📸 스크린샷

<img width="1700" height="928" alt="스크린샷 2025-10-30 오후 4 52 45" src="https://github.com/user-attachments/assets/657d60e4-b9cf-4615-b52c-ca4200785031" />

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 지원자 조회 모달에서 지원자 카드를 클릭하면, 지원자 상세 조회 모달이 뜨도록 연결했습니다.
2. 흥주님이 구현하신 store의 modalKey를 활용하여 모달 상태를 제어했습니다.
3. selectedApplicantId 변수는 추후 API 연동 시 사용할 예정으로, ESLint 규칙에 맞게 _selectedApplicantId로 임시 변경했습니다.
