### PR TITLE
#207 공고관리_ 목록선택 시 상세페이지 이동 기능 추가

### DIFF
--- a/src/components/recruit/recruitCard/RecruitCard.tsx
+++ b/src/components/recruit/recruitCard/RecruitCard.tsx
@@ -50,8 +50,7 @@ const RecruitCard = ({
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [bookmarked, setBookmarked] = useState<boolean>(is_bookmarked)
 
-  const goDetail = () =>
-    navigate(isMine ? `/recruit/manage/${id}` : `/recruit/${id}`)
+  const goDetail = () => navigate(`/recruit/${id}`)
 
   const handleEdit = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #207

## 📸 스크린샷
<img width="1090" height="703" alt="image" src="https://github.com/user-attachments/assets/7b361c3e-d5f1-4c43-ad42-3b9430bee9d9" />

<img width="431" height="245" alt="image" src="https://github.com/user-attachments/assets/912e0327-137d-4b0e-892a-ccfe8a861a2e" />


## 📝 작업 내용

> 목록카드 클릭 시 상세페이지 이동 기능 추가

1. 디테일 페이지로 이동하는 라우터 추가
2. 수정 페이지로 이동하는 라우터 수정
3. 카드 호버 시 마우스커서와 카드색 변경
4. 버튼 이벤트 버블링 방지

현재 공고관리 > 공고관리상세페이지 라우터는 구현 되어 있지 않은거같아 임의로 주소 지정 하여 NotFound 페이지가 나옵니다.

http://localhost:5173/recruit
http://localhost:5173/recruit/manage  에서 확인가능합니다
