### PR TITLE
#234 작성시 태그 선택 모달__검색할 때 페이지값 초기화 안됨

### DIFF
--- a/src/components/recruit/write/tagSelectModal/TagSelectModal.tsx
+++ b/src/components/recruit/write/tagSelectModal/TagSelectModal.tsx
@@ -162,6 +162,7 @@ const TagSelectModal = ({ isOn, onClose }: TagSelectModal) => {
   // 검색 함수
   const onSearchTag = useCallback((tagName: string) => {
     setSearchKeyword(tagName)
+    setCurrent(1)
     // if (tagName === '') {
     //   setResponseData(EXAMPLE_DATA)
     // }


### PR DESCRIPTION

close #234

## 📸 스크린샷

## 📝 작업 내용

> 검색 할때 마다 page 값 1로 초기화함

1. 검색할때마다 page 상태값 1로 초기화


직전에 구현했던 코드에는 페이지 초기화 로직이 있었는데 그 부분 실수로 지웠나 보네요.
버그 체크 감사합니다.
