### PR TITLE
#271 채팅__채팅위젯 스켈레톤 출력

### DIFF
--- a/src/pages/layout/Layout.tsx
+++ b/src/pages/layout/Layout.tsx
@@ -3,10 +3,10 @@ import FlexOneContainer from '../../components/commonInGeneral/layout/_FlexOneCo
 import FullScreen from '../../components/commonInGeneral/layout/_FullScreen'
 import Header from '../../components/layout/header/Header'
 import FloatingButtonContainer from '@/components/layout/floatingButton/FloatingButtonContainer'
-import FloatingButton from '@/components/layout/floatingButton/FloatingButton'
-import { ArrowUp } from 'lucide-react'
 import { lazy, Suspense, useRef } from 'react'
 import FloatingButtonSkeleton from '@/components/chat/skeleton/FloatingButtonSkeleton'
+import FloatingButton from '@/components/layout/floatingButton/FloatingButton'
+import { ArrowUp } from 'lucide-react'
 
 const ChatWidget = lazy(() => import('@/components/chat/ChatWidget'))
 const ChatFloatingButton = lazy(
@@ -33,16 +33,17 @@ const Layout = () => {
 
         {/* 플로팅 아이콘 */}
         <FloatingButtonContainer>
-          {/* 위로가기 아이콘 */}
-          <FloatingButton theme="mono" onClick={onClickTop}>
-            <ArrowUp size={24} strokeWidth={4} />
-          </FloatingButton>
-
-          {/* 메시지 아이콘 */}
           <Suspense fallback={<FloatingButtonSkeleton />}>
+            {/* 위로가기 아이콘 */}
+            <FloatingButton theme="mono" onClick={onClickTop}>
+              <ArrowUp size={24} strokeWidth={4} />
+            </FloatingButton>
+
+            {/* 메시지 아이콘 */}
             <ChatFloatingButton />
           </Suspense>
         </FloatingButtonContainer>
+
         {/* 채팅 */}
         <Suspense fallback={null}>
           <ChatWidget />


### PR DESCRIPTION

close #271

## 📸 스크린샷
<img width="488" height="591" alt="스크린샷 2025-11-06 오후 3 11 53" src="https://github.com/user-attachments/assets/15cd9770-ef2b-4a85-b615-badf318f19bf" />


## 📝 작업 내용

> 채팅 위젯 스켈레톤 제거

1. 채팅 위젯 스켈레톤 제거
2. 채팅 아이콘 로딩중에 위로가기 아이콘 미 출력으로 변경

비로그인 상황에서 위로가기 아이콘이 채팅 아이콘 스켈레톤에 밀려서 위 아래로 이동하는걸 확인하고 채팅 아이콘 로딩중에는 위로가기 아이콘을 출력하지 않도록 변경 했습니다.
