### PR TITLE
#277 공통컴포넌트_공고카드 내용물 바깥으로 나가는 버그 

### DIFF
--- a/src/components/recruit/recruitCard/RecruitCard.tsx
+++ b/src/components/recruit/recruitCard/RecruitCard.tsx
@@ -29,7 +29,7 @@ const RecruitCard = ({
   recruit,
   isMine = false,
   cardClassName = 'cursor-pointer hover:bg-gray-50 transition',
-  imageClassName = 'h-20 w-28',
+  imageClassName = 'h-27 w-35',
 }: RecruitCardProps) => {
   const {
     id,
@@ -108,7 +108,7 @@ const RecruitCard = ({
             />
           </RoundBox>
 
-          <Vstack gap="xs" padding="none" className="flex-1">
+          <Vstack gap="xs" padding="none" className="flex-1 overflow-hidden">
             <Hstack
               gap="none"
               padding="none"
@@ -116,14 +116,14 @@ const RecruitCard = ({
             >
               <h1
                 aria-label="제목"
-                className="truncate text-base font-bold text-gray-900"
+                className="line-clamp-2 flex-1 text-lg font-bold break-words text-gray-900 md:text-xl"
               >
                 {title}
               </h1>
               <Hstack
                 gap="sm"
                 padding="xs"
-                className="shrink-0 items-center text-[11px] leading-none text-gray-500"
+                className="shrink-0 items-center text-sm leading-none text-gray-500"
               >
                 <span
                   aria-label="조회수"
@@ -149,7 +149,7 @@ const RecruitCard = ({
                     <button
                       type="button"
                       aria-label="수정"
-                      className="cursor-pointer text-gray-500 transition hover:text-blue-600"
+                      className="cursor-pointer text-gray-600 transition hover:text-blue-600"
                       onClick={(e) => handleEdit(e)}
                     >
                       <Pencil className="size-3.5" />
@@ -157,7 +157,7 @@ const RecruitCard = ({
                     <button
                       type="button"
                       aria-label="삭제"
-                      className="cursor-pointer text-gray-500 transition hover:text-red-600"
+                      className="cursor-pointer text-gray-600 transition hover:text-red-600"
                       onClick={(e) => handleDelete(e)}
                     >
                       <Trash2 className="size-3.5" />
@@ -170,10 +170,10 @@ const RecruitCard = ({
             <Vstack
               gap="lg"
               padding="xs"
-              className="mt-2 text-xs text-gray-500"
+              className="text-md mt-3 text-gray-600"
             >
               <Hstack
-                gap="xs"
+                gap="sm"
                 padding="none"
                 aria-label="모집인원수"
                 className="items-center"
@@ -184,7 +184,7 @@ const RecruitCard = ({
               </Hstack>
 
               <Hstack
-                gap="xs"
+                gap="sm"
                 padding="none"
                 aria-label="마감일"
                 className="items-center"
@@ -196,8 +196,8 @@ const RecruitCard = ({
               </Hstack>
             </Vstack>
 
-            <Vstack gap="xs" padding="none" className="mt-2 text-gray-500">
-              <Hstack gap="sm" padding="xs" className="text-xs">
+            <Vstack gap="xs" padding="none" className="mt-2 text-gray-600">
+              <Hstack gap="sm" padding="xs" className="text-md">
                 강의 목록 :
               </Hstack>
               <ul className="list-inside list-disc pl-2">
@@ -205,7 +205,7 @@ const RecruitCard = ({
                   <li
                     key={lectures.id}
                     aria-label="강의목록"
-                    className="text-xs"
+                    className="text-md"
                   >
                     {lectures.title}-{lectures.instructor}
                   </li>
@@ -216,7 +216,7 @@ const RecruitCard = ({
             <Hstack
               gap="xs"
               padding="xs"
-              className="items-center justify-between"
+              className="mt-3 items-center justify-between"
             >
               <Hstack
                 gap="sm"
@@ -225,7 +225,12 @@ const RecruitCard = ({
                 className="flex-wrap"
               >
                 {tags.map((tag) => (
-                  <Tag key={tag.id} color="primary" isVivid={false}>
+                  <Tag
+                    key={tag.id}
+                    color="primary"
+                    isVivid={false}
+                    className="!text-sm"
+                  >
                     {tag.name}
                   </Tag>
                 ))}
@@ -234,7 +239,7 @@ const RecruitCard = ({
                 <Hstack gap="none" padding="none" className="self-center">
                   <Button
                     color="blue"
-                    className="gap-2 px-6 py-2 text-xs"
+                    className="gap-2 px-6 py-2 text-sm"
                     onClick={(e) => {
                       e.stopPropagation()
                       setManageOpen(true)


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #277

## 📸 스크린샷
<img width="1084" height="672" alt="image" src="https://github.com/user-attachments/assets/f43e40ac-1c21-4f85-b42a-68c286b01b5f" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1.  추천공고 부분 북마크, 조회수, 글자들 카드 밖으로 나가는 버그 수정
2. 칸이 모자라면 두줄로 줄바꿈 기능 추가(제목부분 transition 제거)
3. 피그마와 카드모양 달라 글자크기 키움
4. 태그 글자크기 변경불가로 강제 변경로직 추가

추천공고 카드 크기는 RecommendUser.tsx에서 변경 가능 확인(버그아님) 

http://localhost:5173/recruit 에서 확인가능합니다.