### PR TITLE
#279 공고 세부 페이지__북마크 디바운스 적용

### DIFF
--- a/src/components/recruit/detail/_RDBookmarkButton.tsx
+++ b/src/components/recruit/detail/_RDBookmarkButton.tsx
@@ -1,7 +1,9 @@
 import Button from '@/components/commonInGeneral/button/Button'
 import useRecruitDetailMutation from '@/hooks/recruitDetail/useRecruitDetailMutation'
+import useDebounceToggle from '@/hooks/useDebounceToggle'
 import type { RecruitDetail } from '@/types'
 import { Bookmark } from 'lucide-react'
+import { useEffect } from 'react'
 
 const RDBookmarkButton = ({
   recruitDetail,
@@ -11,22 +13,31 @@ const RDBookmarkButton = ({
   isWide?: boolean
 }) => {
   const { toggleBookmarkMutation } = useRecruitDetailMutation(recruitDetail)
+  const { debouncedBoolValue, realTimeBoolValue, toggleBoolValue } =
+    useDebounceToggle(recruitDetail.is_bookmarked)
 
-  const handleClick = () => {
+  useEffect(() => {
+    if (debouncedBoolValue === recruitDetail.is_bookmarked) {
+      return
+    }
+
     const newOne: RecruitDetail = {
       ...recruitDetail,
       is_bookmarked: !recruitDetail.is_bookmarked,
     }
     toggleBookmarkMutation.mutate({ data: undefined, newOne })
-  }
+
+    // NOTE: recruitDetail 넣으면 무한 렌더링 일어남
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedBoolValue])
 
   return (
     <Button
-      variant={recruitDetail.is_bookmarked ? 'contained' : 'outlined'}
+      variant={realTimeBoolValue ? 'contained' : 'outlined'}
       size="lg"
       shape={isWide ? 'rectangle' : 'square'}
-      color={recruitDetail.is_bookmarked ? 'primary' : 'mono'}
-      onClick={handleClick}
+      color={realTimeBoolValue ? 'primary' : 'mono'}
+      onClick={toggleBoolValue}
     >
       <Bookmark size={isWide ? 16 : undefined} />
       {isWide && '북마크'}


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #279

## 📸 스크린샷
<img width="1578" height="688" alt="image" src="https://github.com/user-attachments/assets/080e4999-5a67-49c3-b050-d8058e6f44f7" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 공고 세부 페이지 북마크에 토글 디바운스를 적용했습니다

테스트하기 전에
1. BASE_URL을 익스프레스 서버로 변경해주세요
2. recruit에 /---- 북마크라고 적혀있는 코드 전체를 주석처리 해주세요
3. 아래 코드의 주석을 풀어주세요
```
// recruitRouter.ts

// NOTE: 공고 세부 페이지의 북마크를 테스트하기 위해선 아래를 수정해야 합니다
// 1. 위에 있는 공고관리 페이지의 북마크 부분(recruitRouter.post('/:id/bookmark', ...) 전체를 주석처리 합니다
// 2. 아래의 주석을 해제합니다
// recruitRouter.post('/:recruitId/bookmark', async (_req, res) => {
// ...
```
