### PR TITLE
#305 리프레시 토큰으로 액세스 토큰 발급 받기

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -10,6 +10,7 @@ const api = axios.create({
   timeout: 5000,
 })
 
+// NOTE: 인터셉터 안에서 api를 쓰면 무한 요청이 일어납니다
 export const subApi = axios.create({
   baseURL: BASE_URL,
   withCredentials: true,
@@ -17,8 +18,27 @@ export const subApi = axios.create({
   timeout: 5000,
 })
 
+const getRefreshAndMe = async (): Promise<string> => {
+  const response = await subApi.post('/auth/refresh')
+  const accessToken = response.data.data.access
+
+  const responseMe = await subApi.get('/users/me ', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  const me = responseMe.data
+
+  const state = useStudyHubStore.getState()
+  const setAccessToken = state.setAccessToken
+  const setMe = state.setMe
+
+  setAccessToken(accessToken)
+  setMe(me)
+
+  return accessToken
+}
+
 // 요청 인터셉터
-// NOTE: 액세스 토큰은 요청 실패하고 발급받는 게 아니라 요청 전에 없으면 요청합니다
+// NOTE: 액세스 토큰이 없다면 요청 전에 받습니다
 api.interceptors.request.use(async (config) => {
   const state = useStudyHubStore.getState()
   let accessToken = state.accessToken
@@ -29,26 +49,32 @@ api.interceptors.request.use(async (config) => {
   }
 
   try {
-    const response = await subApi.post('/auth/refresh')
-    accessToken = response.data.data.access
-
-    const responseMe = await subApi.get('/users/me ', {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    })
-    const me = responseMe.data
-
-    const state = useStudyHubStore.getState()
-    const setAccessToken = state.setAccessToken
-    const setMe = state.setMe
-
-    setAccessToken(accessToken)
-    setMe(me)
-
+    accessToken = await getRefreshAndMe()
     config.headers.Authorization = `Bearer ${accessToken}`
     return config
   } catch {
     return config
   }
 })
+
+// NOTE: 가지고 있는 토큰이 만료되었다고 오류를 받으면 재발급 받습니다
+api.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    if (error.response?.status !== 401) {
+      return Promise.reject(error)
+    }
+
+    // 1) 토큰 재발급 시도 엔드포인트 호출 (팀 규칙에 맞게)
+    try {
+      await getRefreshAndMe()
+      // 2) 실패했던 요청 재시도
+      return api(error.config)
+    } catch {
+      // 3) 재발급 실패 → 로그인 페이지로
+      window.location.href = '/login'
+    }
+  }
+)
 
 export default api


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #305

## 📸 스크린샷
<img width="1130" height="952" alt="image" src="https://github.com/user-attachments/assets/8a52fb70-e0d0-4186-8e00-11bdf97687b4" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. api의 인터셉터에서 사용할 subApi라는 인스턴스를 새로 만들었습니다
    - api를 사용하면 실패했을 때 무한 요청이 발생할 수 있습니다
2. 요청 이전에 액세스 토큰이 없으면 요청하고 액세스 토큰을 받은 뒤 원래 요청을 보냅니다
3. 401 에러를 받은 뒤의 로직은 위와의 공통 로직만 분리하고 유지했습니다
4. http://localhost:5173/lecture -> 헤더에서 로그아웃 -> 개발자 도구 -> Application -> Cookies -> 토글 열기 -> refresh_token 삭제 -> 새로고침 -> 네트워크 탭에서 refresh, me 요청을 확인하시면 됩니다
