### PR TITLE
#320 헤더__알림 드롭다운__탭 전환 시 꺼지는 버그

### DIFF
--- a/src/components/layout/header/notification/NotificationBox.tsx
+++ b/src/components/layout/header/notification/NotificationBox.tsx
@@ -17,6 +17,7 @@ const NotificationBox = () => {
   const notificationArray = useNotificationStore(
     (state) => state.notificationArray
   )
+  const selectedTab = useNotificationStore((state) => state.selectedTab)
 
   const { isPending, error, hasNextPage, fetchNextPage } =
     useNotificationsQuery()
@@ -26,6 +27,16 @@ const NotificationBox = () => {
     root: rootRef.current,
     rootMargin: '0px 0px 300px 0px',
   })
+
+  // NOTE: 읽음, 읽지 않음 탭에선 전체 알림을 필터링한 것을 스켈레톤 대용으로 사용하기에 스켈레톤이 필요 없습니다
+  if (isPending && notificationArray.length === 0 && selectedTab === 'all') {
+    return <Skeleton heightInPixel={475} widthInPixel={384} />
+  }
+
+  if (error) {
+    // TODO: 채워 넣기
+    return <p>에러가 발생했을 때 보입니다. 추후 수정해야 합니다</p>
+  }
 
   return (
     <RoundBox
@@ -54,11 +65,6 @@ const NotificationBox = () => {
           className="border-b border-b-gray-200"
           ref={rootRef}
         >
-          {isPending && notificationArray.length === 0 && (
-            <Skeleton heightInPixel={340} className="w-full" />
-          )}
-          {error && <p>에러가 발생했을 때 보입니다. 추후 수정해야 합니다</p>}
-
           {notificationArray.map((notification) => (
             <NotificationCard
               key={notification.id}


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #320

## 📸 스크린샷

<img width="906" height="589" alt="image" src="https://github.com/user-attachments/assets/4ad84c52-3242-4cd7-aeea-15d8e60cb39a" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 탭 최초 전환 시에도 알림 드롭다운이 안 꺼지게 하였습니다

원인은 아래와 같았습니다
1. 클릭 -> microtask(promise) -> macrotask(click event handler) 순서로 비동기 작업이 실행
2. microtask에서 스켈레톤으로 dropdown content 내용물 교체
3. macrotask 단계에서는 dropdown content가 더 이상 click event target을 자손으로 갖지 않음. 외부 클릭으로 인식
