### PR TITLE
#408 공고 목록, 공고 관리 페이지 깜빡임 해결

### DIFF
--- a/src/components/recruit/title/RecruitContent.tsx
+++ b/src/components/recruit/title/RecruitContent.tsx
@@ -11,7 +11,6 @@ import RecruitTagSelect from './_RecruitTagSelect'
 import NoSearchResult from '@/components/commonInProject/noSearchResult/NoSearchResult'
 import RecruitArrangementSelect from './_RecruitOrderingSelect'
 import useRecruitStore from '@/store/recruit/recruitStore'
-import useRecruitsQuery from '@/hooks/recruit/title/useRecruitsQuery'
 
 const RecruitContent = () => {
   const accessToken = useStudyHubStore((state) => state.accessToken)
@@ -21,7 +20,8 @@ const RecruitContent = () => {
     (state) => state.recommendedRecruitArray
   )
   const isSearching = useRecruitStore((state) => state.isSearching)
-  const { hasNextPage, totalCount } = useRecruitsQuery()
+  const hasNextPage = useRecruitStore((state) => state.hasNextPage)
+  const totalCount = useRecruitStore((state) => state.totalCount)
   const requestNextPage = useRecruitStore((state) => state.requestNextPage)
 
   return (

--- a/src/hooks/recruit/title/useRecruitsQuery.ts
+++ b/src/hooks/recruit/title/useRecruitsQuery.ts
@@ -24,6 +24,8 @@ const useRecruitsQuery = () => {
   const setRequestNextPage = useRecruitStore(
     (state) => state.setRequestNextPage
   )
+  const setTotalCount = useRecruitStore((state) => state.setTotalCount)
+  const setHasNextPage = useRecruitStore((state) => state.setHasNextPage)
 
   const params = useMemo(
     () => ({
@@ -58,19 +60,12 @@ const useRecruitsQuery = () => {
     }, [])
 
     setRecruitArray(recruitArray)
-  }, [data, setRecruitArray])
-
-  // 추천 공고 업데이트
-  useEffect(() => {
-    if (!data || !isLoggedIn) {
-      setRecommendedRecruitArray([])
-      return
-    }
-
+    setTotalCount(data.pages[0].count.total)
     if (data.pages[0].recommended_recruitments) {
       setRecommendedRecruitArray(data.pages[0].recommended_recruitments)
     }
-  }, [data, isLoggedIn, setRecommendedRecruitArray])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
 
   useEffect(() => {
     setRequestNextPage(fetchNextPage)
@@ -78,6 +73,10 @@ const useRecruitsQuery = () => {
 
   // 전체 공고 수
   const totalCount = data?.pages[0].count.total ?? 0
+
+  useEffect(() => {
+    setHasNextPage(hasNextPage)
+  }, [hasNextPage, setHasNextPage])
 
   return {
     isPending,

--- a/src/pages/recruit/RecruitListPage.tsx
+++ b/src/pages/recruit/RecruitListPage.tsx
@@ -2,11 +2,13 @@ import RecruitContent from '@/components/recruit/title/RecruitContent'
 import useRecruitsQuery from '@/hooks/recruit/title/useRecruitsQuery'
 import RecruitSkeletone from '../../components/recruit/title/RecruitSkeletone'
 import UnknwonErrorContent from '@/components/commonInGeneral/error/UnknownErrorContent'
+import useRecruitStore from '@/store/recruit/recruitStore'
 
 const RecruitListPage = () => {
   const { isPending, error } = useRecruitsQuery()
+  const recruitArray = useRecruitStore((state) => state.recruitArray)
 
-  if (isPending) {
+  if (isPending && recruitArray.length === 0) {
     return <RecruitSkeletone />
   }
 

--- a/src/pages/recruit/manage/RecruitManagePage.tsx
+++ b/src/pages/recruit/manage/RecruitManagePage.tsx
@@ -2,18 +2,28 @@ import RecruitManageContent from '@/components/recruit/manage/RecruitManageConte
 import useStudyHubStore from '@/store/store'
 import useRecruitManage from '@/hooks/recruit/useRecruitsManageQuery'
 import ManageSkeleton from '@/components/recruit/manage/ManageSkeleton'
-import RecruitContent from '@/components/recruit/title/RecruitContent'
 import UnknwonErrorContent from '@/components/commonInGeneral/error/UnknownErrorContent'
+import useRecruitManageStore from '@/store/recruit/manage/recruitManageStore'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router'
 
 const RecruitManagePage = () => {
   const userId = useStudyHubStore((state) => state.me?.id ?? 0)
   const { isPending, error } = useRecruitManage()
+  const recuitManageArray = useRecruitManageStore(
+    (state) => state.recruitManageArray
+  )
+  const navigate = useNavigate()
 
-  if (!userId) {
-    return <RecruitContent />
-  }
+  useEffect(() => {
+    if (userId) {
+      return
+    }
+    navigate('/recruit')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId])
 
-  if (isPending) {
+  if (isPending && recuitManageArray.length === 0) {
     return <ManageSkeleton />
   }
   if (error) {

--- a/src/store/recruit/_recruitStoreInterface.ts
+++ b/src/store/recruit/_recruitStoreInterface.ts
@@ -21,4 +21,9 @@ export interface RecruitStoreState {
 
   requestNextPage: () => void
   setRequestNextPage: (requestNextPage: () => void) => void
+
+  hasNextPage: boolean
+  setHasNextPage: (hasNextPage: boolean) => void
+  totalCount: number
+  setTotalCount: (totalCount: number) => void
 }

--- a/src/store/recruit/recruitStore.ts
+++ b/src/store/recruit/recruitStore.ts
@@ -21,6 +21,11 @@ const useRecruitStore = create<RecruitStoreState>()((set) => ({
 
   requestNextPage: () => {},
   setRequestNextPage: (requestNextPage) => set({ requestNextPage }),
+
+  hasNextPage: false,
+  setHasNextPage: (hasNextPage) => set({ hasNextPage }),
+  totalCount: 0,
+  setTotalCount: (totalCount) => set({ totalCount }),
 }))
 
 export default useRecruitStore


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #408

## 📸 스크린샷
(없음)

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 공고 관리, 목록 페이지에서 스켈레톤 보여주는 조건에 빈 배열도 추가
2. 공고 목록 페이지에서 추천 섹션 깜빡이지 않게 수정
