### PR TITLE
#449 채팅___무한 스크롤 버그

### DIFF
--- a/src/components/chat/ChattingRoom.tsx
+++ b/src/components/chat/ChattingRoom.tsx
@@ -11,6 +11,7 @@ import { useChatRoomMessage } from '@/hooks/chat/useChat'
 import { useEffect, useRef } from 'react'
 import useChatStore from '@/store/chat/chatStore'
 import ChatError from './feat/ChatError'
+import type { ChatMessage } from '@/types/_chat'
 
 // 현재 온라인 유저 명수 표기
 const OnlineUser = ({ isPending }: { isPending: boolean }) => {
@@ -28,11 +29,11 @@ const ChattingRoom = () => {
   const chatState = useChatStore((state) => state.chatState)
   const openChatList = useChatStore((state) => state.openChatList)
   const setChatMessageArray = useChatStore((state) => state.setChatMessageArray)
-  // const chatMessageArray = useChatStore((state) => state.chatMessageArray)
+  const chatMessageArray = useChatStore((state) => state.chatMessageArray)
   const chatInit = useChatStore((state) => state.chatInit)
 
-  // const page = useChatStore((state) => state.page)
-  // const setPage = useChatStore((state) => state.setPage)
+  const page = useChatStore((state) => state.page)
+  const setPage = useChatStore((state) => state.setPage)
   const chatOnline = useChatStore((state) => state.chatOnline)
 
   const {
@@ -56,11 +57,11 @@ const ChattingRoom = () => {
   })
 
   // 데이터 저장, 정렬
-  // const sortMessage = (message: ChatMessage[]) => {
-  //   return message.sort(
-  //     (a, b) => Date.parse(a.created_at) - Date.parse(b.created_at)
-  //   )
-  // }
+  const sortMessage = (message: ChatMessage[]) => {
+    return message.sort(
+      (a, b) => Date.parse(a.created_at) - Date.parse(b.created_at)
+    )
+  }
 
   // 메시지 정렬, 메시지 배열 초기화
   useEffect(() => {
@@ -72,33 +73,35 @@ const ChattingRoom = () => {
       if (!messageArray) {
         return
       }
-      const allMessage = [...messageArray].flatMap((res) => res || []) || []
-      setChatMessageArray(allMessage)
+      // const allMessage = [...messageArray].flatMap((res) => res || []) || []
+      // setChatMessageArray(allMessage)
 
       // 초기화
-      // if (page === 0) {
-      //   if (data.pageParams.length === 0) {
-      //     const allMessage = [...messageArray].flatMap((res) => res || []) || []
-      //     const sortMessaged = sortMessage(allMessage)
-      //     setChatMessageArray(sortMessaged)
-      //   } else {
-      //     const allMessage =
-      //       data?.pages.flatMap((res) => res.results || []) || []
-      //     const sortMessaged = sortMessage(allMessage)
-      //     setChatMessageArray(sortMessaged)
-      //   }
-      // } else {
-      //   const allMessage =
-      //     [...chatMessageArray, ...messageArray].flatMap((res) => res || []) ||
-      //     []
-      //   const sortMessaged = sortMessage(allMessage)
+      if (page === 0) {
+        if (data.pageParams.length === 0) {
+          const allMessage = [...messageArray].flatMap((res) => res || []) || []
+          const sortMessaged = sortMessage(allMessage)
+          setChatMessageArray(sortMessaged)
+        } else {
+          const allMessage =
+            data?.pages.flatMap((res) => res.results || []) || []
+          const sortMessaged = sortMessage(allMessage)
+          setChatMessageArray(sortMessaged)
+        }
+      } else {
+        const allMessage =
+          [...chatMessageArray, ...messageArray].flatMap((res) => res || []) ||
+          []
+        const sortMessaged = sortMessage(allMessage)
 
-      //   setChatMessageArray(sortMessaged)
-      // }
+        setChatMessageArray(sortMessaged)
+      }
 
-      // setPage(data.pageParams.length)
+      setPage(data.pageParams.length)
     }
-  }, [data, isFetchingNextPage, setChatMessageArray])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, isFetchingNextPage])
 
   if (chatState.status !== 'chatRoom') {
     return

--- a/src/components/chat/feat/ChatDisplay.tsx
+++ b/src/components/chat/feat/ChatDisplay.tsx
@@ -1,7 +1,6 @@
 import { Vstack } from '@/components/commonInGeneral/layout'
 import ChatBox from './ChatBox'
 import ChattingRoomSkeleton from '../skeleton/ChattingRoomSkeleton'
-import Skeleton from '@/components/commonInGeneral/skeleton/Skeleton'
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import {
   elementScroll,
@@ -42,6 +41,14 @@ const ChatDisplay = ({
   }
   const scrollToFn: VirtualizerOptions<HTMLDivElement, Element>['scrollToFn'] =
     useCallback((offset, canSmooth, instance) => {
+      if (canSmooth.behavior === 'auto') {
+        instance.scrollElement?.scrollTo({
+          top: offset,
+          behavior: 'auto',
+        })
+        return
+      }
+
       const duration = 1000
       const start = containerRef.current?.scrollTop || 0
       const startTime = (scrollingRef.current = Date.now())
@@ -70,7 +77,7 @@ const ChatDisplay = ({
     getScrollElement: () => containerRef.current, //스크롤 요소
     estimateSize: (_) => 120, // 각 메시지 예상 높이
     overscan: 30, // 화면 바깥에 미리 렌더링 할 메시지 수
-    enabled: !isPending,
+    enabled: !isPending && chatMessageArray.length !== 0,
     scrollToFn,
     // scrollPaddingEnd: 100,
   })
@@ -156,7 +163,7 @@ const ChatDisplay = ({
       if (chatScrollBottom) {
         rowVirtualizer.scrollToIndex(chatMessageArray.length - 1, {
           align: 'center',
-          behavior: 'smooth',
+          behavior: 'auto',
         })
         // previndex.current = chatMessageArray.length
       }
@@ -180,9 +187,9 @@ const ChatDisplay = ({
       {/* 무한 스크롤 */}
       <div ref={LoadingRef} className="m-0 h-0 p-0"></div>
       {isPending && <ChattingRoomSkeleton />}
-      {isFetchingNextPage && (
+      {/* {isFetchingNextPage && (
         <Skeleton widthInPixel={270} heightInPixel={100} className="shrink-0" />
-      )}
+      )} */}
 
       {/* 가상화 리스트 적용 */}
       <div


### PR DESCRIPTION
close #449

## 📸 스크린샷

## 📝 작업 내용

> 무한 스크롤 하면 기존에 있던 데이터 날라가는 버그 제거

1. 기존에 있던 무한 스크롤시 정렬 알고리즘 원상 복구
2. 채팅 보낼때 부드럽게 내려가는 애니메이션제거
3. 무한 스크롤 스켈레톤 제거


채팅 주고 받을떄 애니메이션 제거한 이유는 한번에 여러번 보내면 아래로 안내려가고 그 자리에 멈춰 있어서 제거 했습니다.
